### PR TITLE
gem faker の記述場所をtestからdevelopment test に変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'rails-controller-testing'
   gem 'capybara'
+  gem 'faker', "~> 2.8"
 end
 
 group :development do
@@ -54,7 +55,7 @@ group :development do
 end
 
 group :test do
-  gem 'faker', "~> 2.8"
+  
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
#what
gem faker の記述場所をtestからdevelopment testに変更
#why
他の検証ツール（rspec-rails、factory_bot_rails）と記述場所を統一。
開発環境でfakerが読み込めずサーバーが起動できなかったため
